### PR TITLE
Fixed DataContext = null to clear UI

### DIFF
--- a/Avalonia.PropertyGrid/ViewModels/PropertyGridViewModel.cs
+++ b/Avalonia.PropertyGrid/ViewModels/PropertyGridViewModel.cs
@@ -366,6 +366,8 @@ namespace Avalonia.PropertyGrid.ViewModels
 
             if(_Context == null)
             {
+                CategoryFilter = null;
+                PropertyDescriptorChanged?.Invoke(this, EventArgs.Empty);
                 return;
             }
 


### PR DESCRIPTION
`DataContext = null` was not clearing UI controls because `PropertyDescriptorChanged` event was not firing on null.