### PR TITLE
Remove unwanted dependencies

### DIFF
--- a/Avalonia.PropertyGrid/Avalonia.PropertyGrid.csproj
+++ b/Avalonia.PropertyGrid/Avalonia.PropertyGrid.csproj
@@ -37,7 +37,6 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.0.6" />
     <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.0.6" />
-    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Avalonia.PropertyGrid/Avalonia.PropertyGrid.csproj
+++ b/Avalonia.PropertyGrid/Avalonia.PropertyGrid.csproj
@@ -37,7 +37,6 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.0.6" />
     <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.0.6" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.6" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
 

--- a/Avalonia.PropertyGrid/Controls/ButtonEdit.axaml.cs
+++ b/Avalonia.PropertyGrid/Controls/ButtonEdit.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Interactivity;
 using PropertyModels.ComponentModel;
 using System;
 using System.Windows.Input;
+using Avalonia.Reactive;
 
 namespace Avalonia.PropertyGrid.Controls
 {
@@ -122,7 +123,7 @@ namespace Avalonia.PropertyGrid.Controls
         /// </summary>
         static ButtonEdit()
         {
-            TextProperty.Changed.Subscribe(OnTextProperyChanged);
+            TextProperty.Changed.Subscribe(new AnonymousObserver<AvaloniaPropertyChangedEventArgs<string>>(OnTextProperyChanged));
         }
 
         /// <summary>

--- a/Avalonia.PropertyGrid/Controls/CheckedMask.axaml.cs
+++ b/Avalonia.PropertyGrid/Controls/CheckedMask.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.PropertyGrid.Localization;
 using PropertyModels.ComponentModel;
 using System;
+using Avalonia.Reactive;
 
 namespace Avalonia.PropertyGrid.Controls
 {
@@ -59,7 +60,7 @@ namespace Avalonia.PropertyGrid.Controls
         /// </summary>
         static CheckedMask()
         {
-            ModelProperty.Changed.Subscribe(OnModelChanged);
+            ModelProperty.Changed.Subscribe(new AnonymousObserver<AvaloniaPropertyChangedEventArgs<CheckedMaskModel>>(OnModelChanged));
         }
 
         /// <summary>

--- a/Avalonia.PropertyGrid/Controls/Factories/Builtins/BindingListCellEditFactory.cs
+++ b/Avalonia.PropertyGrid/Controls/Factories/Builtins/BindingListCellEditFactory.cs
@@ -3,7 +3,6 @@ using Avalonia.Logging;
 using PropertyModels.ComponentModel;
 using PropertyModels.Extensions;
 using Avalonia.PropertyGrid.Services;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/Avalonia.PropertyGrid/Controls/ListEdit.axaml.cs
+++ b/Avalonia.PropertyGrid/Controls/ListEdit.axaml.cs
@@ -14,6 +14,7 @@ using Avalonia.Interactivity;
 using Avalonia.PropertyGrid.Services;
 using System.Collections;
 using Avalonia.Platform;
+using Avalonia.Reactive;
 
 namespace Avalonia.PropertyGrid.Controls
 {
@@ -188,7 +189,7 @@ namespace Avalonia.PropertyGrid.Controls
         /// </summary>
         static ListEdit()
         {
-            DataListProperty.Changed.Subscribe(OnDataListChanged);
+            DataListProperty.Changed.Subscribe(new AnonymousObserver<AvaloniaPropertyChangedEventArgs<IList>>(OnDataListChanged));
         }
 
         /// <summary>

--- a/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
+++ b/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
@@ -18,6 +18,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using Avalonia.Reactive;
 
 namespace Avalonia.PropertyGrid.Controls
 {
@@ -195,11 +196,11 @@ namespace Avalonia.PropertyGrid.Controls
         /// </summary>
         static PropertyGrid()
         {            
-            AllowFilterProperty.Changed.Subscribe(OnAllowFilterChanged);
-            AllowQuickFilterProperty.Changed.Subscribe(OnAllowQuickFilterChanged);
-            ShowStyleProperty.Changed.Subscribe(OnShowStyleChanged);
-            ShowTitleProperty.Changed.Subscribe(OnShowTitleChanged);
-			NameWidthProperty.Changed.Subscribe(OnNameWidthChanged);
+            AllowFilterProperty.Changed.Subscribe(new AnonymousObserver<AvaloniaPropertyChangedEventArgs<bool>>(OnAllowFilterChanged));
+            AllowQuickFilterProperty.Changed.Subscribe(new AnonymousObserver<AvaloniaPropertyChangedEventArgs<bool>>(OnAllowQuickFilterChanged));
+            ShowStyleProperty.Changed.Subscribe(new AnonymousObserver<AvaloniaPropertyChangedEventArgs<PropertyGridShowStyle>>(OnShowStyleChanged));
+            ShowTitleProperty.Changed.Subscribe(new AnonymousObserver<AvaloniaPropertyChangedEventArgs<bool>>(OnShowTitleChanged));
+			NameWidthProperty.Changed.Subscribe(new AnonymousObserver<AvaloniaPropertyChangedEventArgs<double>>(OnNameWidthChanged));
         }
 
 


### PR DESCRIPTION
Hi!
Currently, Avalonia.PropertyGrid brings some unwanted dependencies to the users projects:

1. Avalonia.Diagnostics - typically, Avalonia.Diagnostics is only included in Debug builds of applications. And only included in the executable projects. Having it controls library will force every app to always include them.

2. System.Reactive - by itself isn't really an issue. But might add some unwanted binary size, and isn't really used in the project, aside from Subscribe extension, which can be replaced with AnonymousObserver.