### PR TITLE
add a "CategoryBuitin" style option to show by categories that are not alphabetically ordered

### DIFF
--- a/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
+++ b/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
@@ -451,6 +451,10 @@ namespace Avalonia.PropertyGrid.Controls
                     {
                         BuildCategoryPropertiesView(target, referencePath);
                     }
+                    else if (propertyGridShowStyle == PropertyGridShowStyle.CategoryBuiltin)
+                    {
+                    BuildCategoryPropertiesView(target, referencePath, false);
+                    }
                     else if (propertyGridShowStyle == PropertyGridShowStyle.Alphabetic)
                     {
                         BuildAlphabeticPropertiesView(target, referencePath);
@@ -480,16 +484,23 @@ namespace Avalonia.PropertyGrid.Controls
         /// </summary>
         /// <param name="target">The target.</param>
         /// <param name="referencePath">The reference path.</param>
-        protected virtual void BuildCategoryPropertiesView(object target, ReferencePath referencePath)
+        protected virtual void BuildCategoryPropertiesView(object target, ReferencePath referencePath, bool alphabeticSort = true)
         {
             propertiesGrid.ColumnDefinitions.Clear();
 
-            foreach (var categoryInfo in ViewModel.Categories)
+            var categories = ViewModel.Categories;
+
+            if (alphabeticSort)
+            {
+                categories = categories.OrderBy(x => x.Key).ToDictionary(pair => pair.Key, pair => pair.Value);
+            }
+
+            foreach (var categoryInfo in categories)
             {
                 propertiesGrid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
 
                 Expander expander = new Expander();
-                expander.ExpandDirection = ExpandDirection.Down;                
+                expander.ExpandDirection = ExpandDirection.Down;
                 expander.SetValue(Grid.RowProperty, propertiesGrid.RowDefinitions.Count - 1);
                 expander.IsExpanded = true;
                 expander.HorizontalContentAlignment = Layout.HorizontalAlignment.Stretch;

--- a/Avalonia.PropertyGrid/ViewModels/PropertyGridViewModel.cs
+++ b/Avalonia.PropertyGrid/ViewModels/PropertyGridViewModel.cs
@@ -28,6 +28,11 @@ namespace Avalonia.PropertyGrid.ViewModels
         Category,
 
         /// <summary>
+        /// Use category internal order.
+        /// </summary>
+        CategoryBuiltin,
+
+        /// <summary>
         /// The alphabetic
         /// </summary>
         Alphabetic,
@@ -194,7 +199,7 @@ namespace Avalonia.PropertyGrid.ViewModels
         /// Gets the categories.
         /// </summary>
         /// <value>The categories.</value>
-        public SortedList<string, List<PropertyDescriptor>> Categories { get; private set; } = new SortedList<string, List<PropertyDescriptor>>();
+        public Dictionary<string, List<PropertyDescriptor>> Categories { get; private set; } = new Dictionary<string, List<PropertyDescriptor>>();
 
         /// <summary>
         /// Occurs when [filter changed].


### PR DESCRIPTION
I wanted to sort by categories but not have them be alphabetical. This change allows that through a new ShowStyle.

So

        [Category("B")]
        [DisplayName("2")]
        public int Index3 { get; set; }

        [Category("B")]
        [DisplayName("1")]
        public int Index { get; set; }

        [Category("A")]
        [DisplayName("Index")]
        public int Index2 { get; set; }

Shows up as:

![image](https://github.com/user-attachments/assets/17fd7aac-c7bc-4818-bd0d-aa7d7440baa0)

Might not be the best way to do it but I wanted to share in case it is useful for anyone else. Thanks.