### PR TITLE
Various Bugfixes

### DIFF
--- a/Sources/Avalonia.PropertyGrid/Controls/Factories/Builtins/ExpandableCellEditFactory.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/Factories/Builtins/ExpandableCellEditFactory.cs
@@ -24,30 +24,6 @@ namespace Avalonia.PropertyGrid.Controls.Factories.Builtins
         public override int ImportPriority => int.MinValue + 10000;
 
         /// <summary>
-        /// Determines whether [is expandable type] [the specified property].
-        /// </summary>
-        /// <param name="property">The property.</param>
-        /// <returns><c>true</c> if [is expandable type] [the specified property]; otherwise, <c>false</c>.</returns>
-        protected virtual bool IsExpandableType(PropertyDescriptor property)
-        {
-            if (!property.PropertyType.IsClass)
-            {
-                return false;
-            }
-
-            var attr = property.GetCustomAttribute<TypeConverterAttribute>();
-
-            if (attr?.GetConverterType()!.IsChildOf<ExpandableObjectConverter>() == true)
-            {
-                return true;
-            }
-
-            attr = property.PropertyType.GetCustomAttribute<TypeConverterAttribute>();
-
-            return attr?.GetConverterType()!.IsChildOf<ExpandableObjectConverter>() == true;
-        }
-
-        /// <summary>
         /// Handles the new property.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -62,7 +38,7 @@ namespace Avalonia.PropertyGrid.Controls.Factories.Builtins
                 return null;
             }
 
-            if (!IsExpandableType(propertyDescriptor))
+            if (!propertyDescriptor.IsExpandableType())
             {
                 return null;
             }
@@ -125,7 +101,7 @@ namespace Avalonia.PropertyGrid.Controls.Factories.Builtins
                 return false;
             }
 
-            if (!IsExpandableType(propertyDescriptor))
+            if (!propertyDescriptor.IsExpandableType())
             {
                 return false;
             }
@@ -158,7 +134,7 @@ namespace Avalonia.PropertyGrid.Controls.Factories.Builtins
             string? filterText = null,
             bool filterMatchesParentCategory = false)
         {
-            if (!IsExpandableType(context.Property))
+            if (!context.Property.IsExpandableType())
             {
                 return null;
             }

--- a/Sources/Avalonia.PropertyGrid/Controls/Factories/Builtins/ExpandableCellEditFactory.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/Factories/Builtins/ExpandableCellEditFactory.cs
@@ -94,6 +94,7 @@ namespace Avalonia.PropertyGrid.Controls.Factories.Builtins
 
             propertyGrid.DisplayMode = context.Root.DisplayMode;
             propertyGrid.ShowStyle = context.Root.ShowStyle;
+            propertyGrid.NameWidth = context.Root.NameWidth;
             propertyGrid.AllowFilter = false;
             propertyGrid.AllowQuickFilter = false;
             propertyGrid.ShowTitle = false;

--- a/Sources/Avalonia.PropertyGrid/Controls/IPropertyGrid.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/IPropertyGrid.cs
@@ -3,13 +3,14 @@ using System.ComponentModel;
 using Avalonia.Interactivity;
 using Avalonia.PropertyGrid.ViewModels;
 using PropertyModels.ComponentModel;
+using INotifyPropertyChanged = System.ComponentModel.INotifyPropertyChanged;
 
 namespace Avalonia.PropertyGrid.Controls
 {
     /// <summary>
     /// Interface IPropertyGrid
     /// </summary>
-    public interface IPropertyGrid
+    public interface IPropertyGrid: INotifyPropertyChanged, IDisposable
     {
         /// <summary>
         /// Gets the cell edit factory collection.

--- a/Sources/Avalonia.PropertyGrid/Controls/IPropertyGrid.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/IPropertyGrid.cs
@@ -66,6 +66,12 @@ namespace Avalonia.PropertyGrid.Controls
         PropertyGridShowStyle ShowStyle { get; set; }
 
         /// <summary>
+        /// Gets or sets the width of the name.
+        /// </summary>
+        /// <value>The width of the name.</value>
+        double NameWidth { get; set; }
+
+        /// <summary>
         /// Gets or sets the root property grid.
         /// </summary>
         /// <value>The root property grid.</value>

--- a/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
@@ -724,11 +724,7 @@ namespace Avalonia.PropertyGrid.Controls
                     var innerPropertyGrid = innerGrid?.GetVisualChildren().OfType<Grid>()
                         .FirstOrDefault(item => item.Name == "PropertiesGrid");
                     var innerExpander = innerPropertyGrid?.Children.OfType<Expander>().FirstOrDefault();
-
-                    if (innerExpander != null)
-                    {
-                        innerExpander.Header = property.DisplayName;
-                    }
+                    innerExpander?.SetLocalizeBinding(HeaderedContentControl.HeaderProperty, property.DisplayName);
                     break;
 
                 case false:
@@ -736,13 +732,10 @@ namespace Avalonia.PropertyGrid.Controls
                     nameBlock.SetValue(Grid.ColumnProperty, 0);
                     nameBlock.VerticalAlignment = VerticalAlignment.Center;
                     nameBlock.Margin = new Thickness(4);
-
-                    // nameBlock.Text = LocalizationService.Default[property.DisplayName];
                     nameBlock.SetLocalizeBinding(TextBlock.TextProperty, property.DisplayName);
 
                     if (property.GetCustomAttribute<DescriptionAttribute>() is { } descriptionAttribute && descriptionAttribute.Description.IsNotNullOrEmpty())
                     {
-                        // nameBlock.SetValue(ToolTip.TipProperty, LocalizationService.Default[descriptionAttribute.Description]);
                         nameBlock.SetLocalizeBinding(ToolTip.TipProperty, descriptionAttribute.Description);
                     }
 

--- a/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
@@ -490,11 +490,11 @@ namespace Avalonia.PropertyGrid.Controls
         {
             if (e.Sender is PropertyGrid sender)
             {
-                sender.OnIsReadOnIsReadOnyPropertyChanged(e.OldValue.Value, e.NewValue.Value);
+                sender.OnIsReadOnIsReadOnlyPropertyChanged(e.OldValue.Value, e.NewValue.Value);
             }
         }
 
-        private void OnIsReadOnIsReadOnyPropertyChanged(bool oldValue, bool newValue) => ViewModel.IsReadOnly = newValue;
+        private void OnIsReadOnIsReadOnlyPropertyChanged(bool oldValue, bool newValue) => ViewModel.IsReadOnly = newValue;
 
         private static void OnAllowQuickFilterChanged(AvaloniaPropertyChangedEventArgs<bool> e)
         {

--- a/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
@@ -524,7 +524,7 @@ namespace Avalonia.PropertyGrid.Controls
         private void OnShowTitleChanged(bool oldValue, bool newValue)
         {
             SplitterGrid.Opacity = newValue ? 1 : 0;
-            SplitterGrid.Height = 0;
+            SplitterGrid.Height = newValue ? double.NaN : 0;
         }
 
         private static void OnIsReadOnlyPropertyChanged(AvaloniaPropertyChangedEventArgs<bool> e)

--- a/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
@@ -272,7 +272,7 @@ namespace Avalonia.PropertyGrid.Controls
             _ = PropertyOrderStyleProperty.Changed.Subscribe(new AnonymousObserver<AvaloniaPropertyChangedEventArgs<PropertyGridOrderStyle>>(OnPropertyOrderStyleChanged));
             _ = ShowTitleProperty.Changed.Subscribe(new AnonymousObserver<AvaloniaPropertyChangedEventArgs<bool>>(OnShowTitleChanged));
             _ = NameWidthProperty.Changed.Subscribe(new AnonymousObserver<AvaloniaPropertyChangedEventArgs<double>>(OnNameWidthChanged));
-            _ = IsReadOnlyProperty.Changed.Subscribe(new AnonymousObserver<AvaloniaPropertyChangedEventArgs<bool>>(OnIsReadOnyPropertyChanged));
+            _ = IsReadOnlyProperty.Changed.Subscribe(new AnonymousObserver<AvaloniaPropertyChangedEventArgs<bool>>(OnIsReadOnlyPropertyChanged));
         }
 
         /// <summary>
@@ -486,15 +486,15 @@ namespace Avalonia.PropertyGrid.Controls
 
         private void OnShowTitleChanged(bool oldValue, bool newValue) => SplitterGrid.IsVisible = newValue;
 
-        private static void OnIsReadOnyPropertyChanged(AvaloniaPropertyChangedEventArgs<bool> e)
+        private static void OnIsReadOnlyPropertyChanged(AvaloniaPropertyChangedEventArgs<bool> e)
         {
             if (e.Sender is PropertyGrid sender)
             {
-                sender.OnIsReadOnyPropertyChanged(e.OldValue.Value, e.NewValue.Value);
+                sender.OnIsReadOnIsReadOnyPropertyChanged(e.OldValue.Value, e.NewValue.Value);
             }
         }
 
-        private void OnIsReadOnyPropertyChanged(bool oldValue, bool newValue) => ViewModel.IsReadOnly = newValue;
+        private void OnIsReadOnIsReadOnyPropertyChanged(bool oldValue, bool newValue) => ViewModel.IsReadOnly = newValue;
 
         private static void OnAllowQuickFilterChanged(AvaloniaPropertyChangedEventArgs<bool> e)
         {

--- a/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
@@ -760,7 +760,7 @@ namespace Avalonia.PropertyGrid.Controls
             grid.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
 
             var nameBlock = new HighlightedTextBlock();
-            var shouldUseInlineMode = this.DisplayMode == PropertyGridDisplayMode.Inline && this.IsExpandableType(property);
+            var shouldUseInlineMode = this.DisplayMode == PropertyGridDisplayMode.Inline && property.IsExpandableType();
             switch (shouldUseInlineMode)
             {
                 case true:
@@ -808,30 +808,6 @@ namespace Avalonia.PropertyGrid.Controls
             };
 
             container.Add(cellInfo);
-        }
-
-        /// <summary>
-        /// Determines whether [is expandable type] [the specified property].
-        /// </summary>
-        /// <param name="property">The property.</param>
-        /// <returns><c>true</c> if [is expandable type] [the specified property]; otherwise, <c>false</c>.</returns>
-        private bool IsExpandableType(PropertyDescriptor property)
-        {
-            if (!property.PropertyType.IsClass)
-            {
-                return false;
-            }
-
-            var attr = property.GetCustomAttribute<TypeConverterAttribute>();
-
-            if (attr?.GetConverterType()!.IsChildOf<ExpandableObjectConverter>() == true)
-            {
-                return true;
-            }
-
-            attr = property.PropertyType.GetCustomAttribute<TypeConverterAttribute>();
-
-            return attr?.GetConverterType()!.IsChildOf<ExpandableObjectConverter>() == true;
         }
 
         #endregion

--- a/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
@@ -531,11 +531,11 @@ namespace Avalonia.PropertyGrid.Controls
         {
             if (e.Sender is PropertyGrid sender)
             {
-                sender.OnIsReadOnIsReadOnlyPropertyChanged(e.OldValue.Value, e.NewValue.Value);
+                sender.OnIsReadOnlyPropertyChanged(e.OldValue.Value, e.NewValue.Value);
             }
         }
 
-        private void OnIsReadOnIsReadOnlyPropertyChanged(bool oldValue, bool newValue) => ViewModel.IsReadOnly = newValue;
+        private void OnIsReadOnlyPropertyChanged(bool oldValue, bool newValue) => ViewModel.IsReadOnly = newValue;
 
         private static void OnAllowQuickFilterChanged(AvaloniaPropertyChangedEventArgs<bool> e)
         {

--- a/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
@@ -42,7 +42,8 @@ namespace Avalonia.PropertyGrid.Controls
         [Category("Views")]
         public bool AllowFilter
         {
-            get => GetValue(AllowFilterProperty); set => SetValue(AllowFilterProperty, value);
+            get => GetValue(AllowFilterProperty); 
+            set => SetValue(AllowFilterProperty, value);
         }
 
         /// <summary>
@@ -57,7 +58,8 @@ namespace Avalonia.PropertyGrid.Controls
         [Category("Views")]
         public bool AllowToggleView
         {
-            get => GetValue(AllowToggleViewProperty); set => SetValue(AllowToggleViewProperty, value);
+            get => GetValue(AllowToggleViewProperty); 
+            set => SetValue(AllowToggleViewProperty, value);
         }
 
         /// <summary>
@@ -72,7 +74,8 @@ namespace Avalonia.PropertyGrid.Controls
         [Category("Views")]
         public bool AllowQuickFilter
         {
-            get => GetValue(AllowQuickFilterProperty); set => SetValue(AllowQuickFilterProperty, value);
+            get => GetValue(AllowQuickFilterProperty); 
+            set => SetValue(AllowQuickFilterProperty, value);
         }
 
         /// <summary>
@@ -87,7 +90,8 @@ namespace Avalonia.PropertyGrid.Controls
         [Category("Views")]
         public bool ShowTitle
         {
-            get => GetValue(ShowTitleProperty); set => SetValue(ShowTitleProperty, value);
+            get => GetValue(ShowTitleProperty); 
+            set => SetValue(ShowTitleProperty, value);
         }
 
         /// <summary>

--- a/Sources/Avalonia.PropertyGrid/ViewModels/PropertyGridViewModel.cs
+++ b/Sources/Avalonia.PropertyGrid/ViewModels/PropertyGridViewModel.cs
@@ -344,7 +344,9 @@ namespace Avalonia.PropertyGrid.ViewModels
                 case PropertyGridCellType.Category:
                     // Check if the filter matches the (parent) category.
                     bool filterMatchesCategory = filterMatchesParentCategory;
-                    if (filterText.IsNotNullOrEmpty() && DisplayMode != PropertyGridDisplayMode.Inline)
+                    bool allChildrenAreExpandable = cellInfo.Children.All(child => child.Context?.Property.IsExpandableType() == true);
+                    bool shouldCheckCategory = this.DisplayMode != PropertyGridDisplayMode.Inline || allChildrenAreExpandable;
+                    if (filterText.IsNotNullOrEmpty() && shouldCheckCategory)
                     {
                         filterMatchesCategory |= cellInfo.Category?.Contains(filterText, StringComparison.CurrentCultureIgnoreCase) ?? false;
                     }

--- a/Sources/PropertyModels/Extensions/PropertyDescriptorExtensions.cs
+++ b/Sources/PropertyModels/Extensions/PropertyDescriptorExtensions.cs
@@ -1,0 +1,34 @@
+﻿namespace PropertyModels.Extensions;
+
+using System.ComponentModel;
+using System.Reflection;
+
+/// <summary>
+/// Extension class for <see cref="PropertyDescriptor"/>s.
+/// </summary>
+public static class PropertyDescriptorExtensions
+{
+    /// <summary>
+    /// Determines whether [is expandable type] [the specified property].
+    /// </summary>
+    /// <param name="property">The property.</param>
+    /// <returns><c>true</c> if [is expandable type] [the specified property]; otherwise, <c>false</c>.</returns>
+    public static bool IsExpandableType(this PropertyDescriptor property)
+    {
+        if (!property.PropertyType.IsClass)
+        {
+            return false;
+        }
+
+        var attr = property.GetCustomAttribute<TypeConverterAttribute>();
+
+        if (attr?.GetConverterType()!.IsChildOf<ExpandableObjectConverter>() == true)
+        {
+            return true;
+        }
+
+        attr = property.PropertyType.GetCustomAttribute<TypeConverterAttribute>();
+
+        return attr?.GetConverterType()!.IsChildOf<ExpandableObjectConverter>() == true;
+    }
+}


### PR DESCRIPTION
This pull request introduces the following bug fixes and improvements:

- Fixed a bug that caused the parent category search to malfunction in some cases when using the inline display mode.
- Fixed a bug that prevented the width of expandable child cell names from updating properly when the width of the parent property grid name changed.
- The `IsExpandableType` method was refactored by moving it into an extension class.

Thank you for quickly merging my last PR and providing a new NuGet package. I really appreciate it! 😊
If possible, I would be very happy about a version 11.3.1 after the PR has been merged.