### PR TITLE
Added Unit Attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ run `dotnet publish` under `Samples/Avalonia.PropertyGrid.Samples.Browser`. This
 
 ## Detail Description
 ### Data Modeling
-If you want to edit an object in PropertyGrid, you only need to directly set this object to the `DataContext` property of PropertyGrid, PropertyGrid will automatically analyze the properties that can support editing, and edit it with the corresponding CellEdit. At the same time, you can also use Attributes in System.ComponentModel and System.ComponentModel.DataAnnotations to mark these properties, so that these properties have some special characteristics.  
+If you want to edit an object in PropertyGrid, you only need to directly set this object to the `DataContext` property of PropertyGrid, PropertyGrid will automatically analyze the properties that can support editing, and edit it with the corresponding CellEdit. At the same time, you can also use Attributes in System.ComponentModel, System.ComponentModel.DataAnnotations and PropertyModels.ComponentModel to mark these properties, so that these properties have some special characteristics.  
 Support but not limited to these:
 ```
 System.ComponentModel.CategoryAttribute                     /* set property category */  
@@ -48,6 +48,7 @@ System.ComponentModel.PasswordPropertyTextAttribute         /* mark text propert
 System.ComponentModel.DataAnnotations.EditableAttribute     /* mark list property can add/remove/clear elements */  
 System.ComponentModel.DataAnnotations.RangeAttribute        /* set numeric range */  
 System.Runtime.Serialization.IgnoreDataMemberAttribute      /* used to hide a property */  
+PropertyModels.ComponentModel.UnitAttribute                 /* used to display a unit next to the display name */  
 ```
 In addition, there are other classes that can be supported in PropertyModels.ComponentModel and PropertyModels.ComponentModel.DataAnnotations, which can assist in describing class properties.  
 If you want to have some associations between your class properties, for example, some properties depend on other properties in implementation, then you can try to mark this dependency with PropertyModels.ComponentModel.DataAnnotations.DependsOnPropertyAttribute  

--- a/Samples/Avalonia.PropertyGrid.Samples/Models/SimpleObject.cs
+++ b/Samples/Avalonia.PropertyGrid.Samples/Models/SimpleObject.cs
@@ -171,41 +171,51 @@ namespace Avalonia.PropertyGrid.Samples.Models
 
         [Category("Numeric")]
         [Range(10, 200)]
+        [Unit("m")]
         public int iValue { get; set; } = 100;
 
         [Category("Numeric")]
         [Range(0.1f, 10.0f)]
+        [Unit("cm")]
         public float fValue { get; set; } = 0.5f;
 
         [Category("Numeric")]
         [Range(0.1f, 10.0f)]
         [FloatPrecision(3)]
+        [Unit("mm")]
         public float fValuePrecision { get; set; } = 0.5f;
 
         [Category("Numeric")]
         [Range(0.1f, 10.0f)]
+        [Unit("rad")]
         public double dValue { get; set; } = 5.5f;
 
         [Category("Numeric")]
+        [Unit("deg")]
         public long i64Value { get; set; } = 1000000000;
 
         [Category("Numeric")]
+        [Unit("m/s\u00b2")]
         public long i64ValueBig { get; set; } = 583792581039233983;
 
         [Category("Numeric")]
+        [Unit("km/h")]
         public decimal decValue { get; set; } = 100.00M;
 
         [Category("Numeric")]
         [Range(typeof(decimal), "10.00001", "1000.9999", ParseLimitsInInvariantCulture = true)]
         [FloatPrecision(3)]
+        [Unit("mp/h")]
         public decimal decValueWithRange { get; set; } = 100.00M;
 
         [Category("Numeric")]
         [Progress]
+        [Unit("%")]
         public double progressValue { get; set; } = 47;
 
         [Category("Numeric")]
         [Trackable(0, 100, Increment = 0.1, FormatString = "{0:0.0}")]
+        [Unit("kg")]
         public double trackableDoubleValue
         {
             get => progressValue;
@@ -221,6 +231,7 @@ namespace Avalonia.PropertyGrid.Samples.Models
 
         [Category("Numeric")]
         [Trackable(-1000, 1000, Increment = 1, FormatString = "{0:0}")]
+        [Unit("t")]
         public int trackableIntValue { get; set; } = 10;
 
         [Category("Array")]

--- a/Sources/Avalonia.PropertyGrid/Controls/HighlightedTextBlock.axaml.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/HighlightedTextBlock.axaml.cs
@@ -1,11 +1,13 @@
 ﻿namespace Avalonia.PropertyGrid.Controls;
 
 using System;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Documents;
 using Avalonia.Media;
 using Avalonia.PropertyGrid.Utils;
+using PropertyModels.ComponentModel;
 
 /// <summary>
 /// Custom Avalonia <see cref="TextBlock"/> which supports highlighting.
@@ -65,10 +67,9 @@ public partial class HighlightedTextBlock : TextBlock
     /// <param name="textToHighlight">The text to highlight.</param>
     private void HighlightText(string? textToHighlight)
     {
+        // Update the inline collection to highlight the matching text.
         InlineCollection inlineCollection = [];
-        if (this.Text is not null &&
-            !string.IsNullOrEmpty(this.Text) &&
-            !string.IsNullOrEmpty(textToHighlight))
+        if (!string.IsNullOrEmpty(this.Text) && !string.IsNullOrEmpty(textToHighlight))
         {
             int startIndex = 0;
             while (startIndex < this.Text.Length)
@@ -99,6 +100,18 @@ public partial class HighlightedTextBlock : TextBlock
 
                 startIndex = index + textToHighlight.Length;
             }
+        }
+        
+        // Add the text as inline if no matching text has been found.
+        if (inlineCollection.Count == 0)
+        {
+            inlineCollection.Add(new Run { Text = this.Text });
+        }
+
+        // Add the previous unit inline back to the inline collection.
+        if (this.Inlines?.FirstOrDefault(item => item.DataContext is UnitAttribute) is Run unitInlineRun)
+        {
+            inlineCollection.Add(unitInlineRun);
         }
 
         this.Inlines = inlineCollection;

--- a/Sources/Avalonia.PropertyGrid/Controls/HighlightedTextBlock.axaml.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/HighlightedTextBlock.axaml.cs
@@ -93,7 +93,8 @@ public partial class HighlightedTextBlock : TextBlock
                     : new SolidColorBrush(Colors.Transparent);
                 inlineCollection.Add(new Run(this.Text.Substring(index, textToHighlight.Length))
                 {
-                    Background = backgroundBrush
+                    Background = backgroundBrush,
+                    Foreground = new SolidColorBrush(Colors.White)
                 });
 
                 startIndex = index + textToHighlight.Length;

--- a/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml
+++ b/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml
@@ -37,7 +37,7 @@
 		<lc:CheckedMask x:Name="FastFilterBox" Grid.Row="1" Model="{Binding $parent[lc:PropertyGrid].ViewModel.CategoryFilter}"></lc:CheckedMask>
 		<Grid x:Name="SplitterGrid" Grid.Row="2">
 			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="180" MinWidth="60"></ColumnDefinition>
+				<ColumnDefinition Width="200" MinWidth="60"></ColumnDefinition>
 				<ColumnDefinition Width="2"></ColumnDefinition>
 				<ColumnDefinition Width="*"></ColumnDefinition>				
 			</Grid.ColumnDefinitions>

--- a/Sources/Avalonia.PropertyGrid/ViewModels/PropertyGridViewModel.cs
+++ b/Sources/Avalonia.PropertyGrid/ViewModels/PropertyGridViewModel.cs
@@ -344,11 +344,10 @@ namespace Avalonia.PropertyGrid.ViewModels
                 case PropertyGridCellType.Category:
                     // Check if the filter matches the (parent) category.
                     bool filterMatchesCategory = filterMatchesParentCategory;
-                    bool allChildrenAreExpandable = cellInfo.Children.All(child => child.Context?.Property.IsExpandableType() == true);
-                    bool shouldCheckCategory = this.DisplayMode != PropertyGridDisplayMode.Inline || allChildrenAreExpandable;
-                    if (filterText.IsNotNullOrEmpty() && shouldCheckCategory)
+                    if (filterText.IsNotNullOrEmpty())
                     {
-                        filterMatchesCategory |= cellInfo.Category?.Contains(filterText, StringComparison.CurrentCultureIgnoreCase) ?? false;
+                        filterMatchesCategory |= (cellInfo.Container?.Header as string)?
+                            .Contains(filterText, StringComparison.CurrentCultureIgnoreCase) ?? false;
                     }
 
                     // Propagate the visibility of all child cell infos.

--- a/Sources/PropertyModels/ComponentModel/UnitAttribute.cs
+++ b/Sources/PropertyModels/ComponentModel/UnitAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace PropertyModels.ComponentModel
+{
+    /// <summary>
+    /// Class UnitAttribute.
+    /// Implements the <see cref="Attribute" />
+    /// </summary>
+    /// <seealso cref="Attribute" />
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class UnitAttribute : Attribute
+    {
+        /// <summary>
+        /// The unit
+        /// </summary>
+        public readonly string Unit;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnitAttribute"/> class.
+        /// </summary>
+        /// <param name="unit">The unit.</param>
+        public UnitAttribute(string unit)
+        {
+            Unit = unit;
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new (optional) attribute called `Unit`, which allows a custom unit string (e.g. "m") to be displayed next to the display name of any entry within the property grid.

**Example:**
![image](https://github.com/user-attachments/assets/d6c1a548-08bd-4263-96cc-01dfde1ae0dc)