### PR TITLE
新增右侧内容特性, 可以在右侧展示一些内容

### DIFF
--- a/Samples/Avalonia.PropertyGrid.Samples/Avalonia.PropertyGrid.Samples.csproj
+++ b/Samples/Avalonia.PropertyGrid.Samples/Avalonia.PropertyGrid.Samples.csproj
@@ -26,11 +26,11 @@
     <PackageReference Include="Avalonia.Themes.Simple" />
   </ItemGroup>
 
-    <ItemGroup Condition="'$(Configuration)' != 'Development'">
-        <PackageReference Include="bodong.Avalonia.PropertyGrid" />
+    <ItemGroup Condition="'$(Configuration)' == 'Development'">
+      <ProjectReference Include="..\..\Sources\Avalonia.PropertyGrid\Avalonia.PropertyGrid.csproj" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(Configuration)' == 'Development'">
+    <ItemGroup>
       <ProjectReference Include="..\..\Sources\Avalonia.PropertyGrid\Avalonia.PropertyGrid.csproj" />
     </ItemGroup>
 

--- a/Samples/Avalonia.PropertyGrid.Samples/FeatureDemos/Models/SimpleObject.cs
+++ b/Samples/Avalonia.PropertyGrid.Samples/FeatureDemos/Models/SimpleObject.cs
@@ -308,6 +308,7 @@ namespace Avalonia.PropertyGrid.Samples.FeatureDemos.Models
         [FloatPrecision(3)]
         [Unit("mp/h")]
         [Description("Decimal value with range and precision representing speed in miles per hour")]
+        [InnerRightContentString("mp/h")]
         public decimal decValueWithRange { get; set; } = 100.00M;
 
         [Category("Numeric")]

--- a/Sources/Avalonia.PropertyGrid/Avalonia.PropertyGrid.csproj
+++ b/Sources/Avalonia.PropertyGrid/Avalonia.PropertyGrid.csproj
@@ -49,11 +49,10 @@
     <PackageReference Include="Avalonia" Version="11.3.1" />
     <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.3.1" />
   </ItemGroup>
-
-    <ItemGroup Condition="'$(Configuration)' != 'Development'">
-        <PackageReference Include="bodong.PropertyModels" Version="11.3.1.1" />
-    </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Development'">
+    <ProjectReference Include="..\PropertyModels\PropertyModels.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\PropertyModels\PropertyModels.csproj" />
   </ItemGroup>
 

--- a/Sources/Avalonia.PropertyGrid/Controls/Factories/Builtins/NumericCellEditFactory.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/Factories/Builtins/NumericCellEditFactory.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.PropertyGrid.Localization;
 using PropertyModels.ComponentModel;
 using PropertyModels.ComponentModel.DataAnnotations;
 using PropertyModels.Extensions;
@@ -74,6 +77,19 @@ public class NumericCellEditFactory : AbstractCellEditFactory
             var values = DecimalConvertUtils.GetDecimalRange(attr);
             control.Minimum = values.Min;
             control.Maximum = values.Max;
+        }
+
+        var innerRightContentAttribute = propertyDescriptor.GetCustomAttribute<InnerRightContentStringAttribute>();
+        if (innerRightContentAttribute != null)
+        {
+            var rightcontent = new TextBlock
+            {
+                Padding = new Thickness(0, 0, 5, 0),
+                Foreground = Brushes.Gray,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            rightcontent.SetLocalizeBinding(TextBlock.TextProperty, innerRightContentAttribute.Content);
+            control.SetValue(TextBox.InnerRightContentProperty, rightcontent);
         }
 
         var formatAttr = propertyDescriptor.GetCustomAttribute<FormatStringAttribute>();

--- a/Sources/Avalonia.PropertyGrid/Controls/Factories/Builtins/StringCellEditFactory.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/Factories/Builtins/StringCellEditFactory.cs
@@ -53,6 +53,19 @@ public class StringCellEditFactory : AbstractCellEditFactory
             control.SetLocalizeBinding(TextBox.WatermarkProperty, watermarkAttr.Watermark);
         }
 
+        var innerRightContentAttribute = propertyDescriptor.GetCustomAttribute<InnerRightContentStringAttribute>();
+        if (innerRightContentAttribute != null)
+        {
+            var rightcontent = new TextBlock
+            {
+                Padding = new Thickness(0, 0, 5, 0),
+                Foreground = Brushes.Gray,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            rightcontent.SetLocalizeBinding(TextBlock.TextProperty, innerRightContentAttribute.Content);
+            control.SetValue(TextBox.InnerRightContentProperty, rightcontent);
+        }
+
         if (propertyDescriptor.GetCustomAttribute<PasswordPropertyTextAttribute>() is { Password: true })
         {
             control.PasswordChar = '*';

--- a/Sources/PropertyModels/ComponentModel/InnerRightContentStringAttribute.cs
+++ b/Sources/PropertyModels/ComponentModel/InnerRightContentStringAttribute.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace PropertyModels.ComponentModel;
+
+/// <summary>
+/// Class WatermarkAttribute.
+/// Implements the <see cref="Attribute" />
+/// </summary>
+/// <seealso cref="Attribute" />
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public class InnerRightContentStringAttribute : Attribute
+{
+    /// <summary>
+    /// The content
+    /// </summary>
+    public readonly string Content;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InnerRightContentStringAttribute"/> class.
+    /// </summary>
+    /// <param name="content">The content.</param>
+    public InnerRightContentStringAttribute(string content)
+    {
+        Content = content;
+    }
+}


### PR DESCRIPTION
在 `Avalonia.PropertyGrid.Samples.csproj` 和 `Avalonia.PropertyGrid.csproj` 中调整项目引用条件，以支持开发配置下的引用。 (原项目下的引用均来自nuget,  开发时不太方便, 因此做了以上调整)
新增 `InnerRightContentString` 特性，允许在 `NumericCellEditFactory` 和 `StringCellEditFactory` 中显示右侧内容。 
同时，定义了 `InnerRightContentStringAttribute` 类以支持该特性。

效果如下图:

<img width="1255" height="425" alt="image" src="https://github.com/user-attachments/assets/84d11974-79eb-4ba2-9305-dcecfae17c05" />
