### PR TITLE
(Minimal) Upgrade to Avalonia V12

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <AvaloniaVersion>11.0.0</AvaloniaVersion>
+    <AvaloniaVersion>12.0.0</AvaloniaVersion>
   </PropertyGroup>
 </Project>

--- a/Samples/Avalonia.PropertyGrid.Samples.Android/AndroidApp.cs
+++ b/Samples/Avalonia.PropertyGrid.Samples.Android/AndroidApp.cs
@@ -1,0 +1,15 @@
+using System;
+using Android.App;
+using Android.Runtime;
+using Avalonia.Android;
+
+namespace Avalonia.PropertyGrid.Samples.Android;
+
+[Application]
+public class AndroidApp : AvaloniaAndroidApplication<App>
+{
+    protected AndroidApp(IntPtr javaReference, JniHandleOwnership transfer)
+        : base(javaReference, transfer)
+    {
+    }
+}

--- a/Samples/Avalonia.PropertyGrid.Samples.Android/Avalonia.PropertyGrid.Samples.Android.csproj
+++ b/Samples/Avalonia.PropertyGrid.Samples.Android/Avalonia.PropertyGrid.Samples.Android.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-android</TargetFramework>
-    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+    <TargetFramework>net10.0-android</TargetFramework>
+    <SupportedOSPlatformVersion>23</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>com.CompanyName.Avalonia.PropertyGrid.Samples</ApplicationId>
     <ApplicationVersion>1</ApplicationVersion>

--- a/Samples/Avalonia.PropertyGrid.Samples.Android/MainActivity.cs
+++ b/Samples/Avalonia.PropertyGrid.Samples.Android/MainActivity.cs
@@ -10,11 +10,6 @@ namespace Avalonia.PropertyGrid.Samples.Android;
     Icon = "@drawable/icon",
     MainLauncher = true,
     ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]
-public class MainActivity : AvaloniaMainActivity<App>
+public class MainActivity : AvaloniaMainActivity
 {
-    protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
-    {
-        return base.CustomizeAppBuilder(builder)
-            .WithInterFont();
-    }
 }

--- a/Samples/Avalonia.PropertyGrid.Samples.Browser/Avalonia.PropertyGrid.Samples.Browser.csproj
+++ b/Samples/Avalonia.PropertyGrid.Samples.Browser/Avalonia.PropertyGrid.Samples.Browser.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WebAssembly">
   <PropertyGroup>
-    <TargetFramework>net9.0-browser</TargetFramework>
+    <TargetFramework>net10.0-browser</TargetFramework>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>

--- a/Samples/Avalonia.PropertyGrid.Samples.Desktop/Avalonia.PropertyGrid.Samples.Desktop.csproj
+++ b/Samples/Avalonia.PropertyGrid.Samples.Desktop/Avalonia.PropertyGrid.Samples.Desktop.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <!--If you are willing to use Windows/MacOS native APIs you will need to create 3 projects.
     One for Windows with net8.0-windows TFM, one for MacOS with net8.0-macos and one with net8.0 TFM for Linux.-->
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <Configurations>Debug;Release;Development</Configurations>
@@ -19,8 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" />
-    <PackageReference Include="Avalonia.Diagnostics" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Condition="'$(Configuration)' != 'Release'" />
+    <!--Condition below is needed to remove AvaloniaUI.DiagnosticsSupport package from build output in Release configuration.-->
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Avalonia.PropertyGrid.Samples.Desktop/Program.cs
+++ b/Samples/Avalonia.PropertyGrid.Samples.Desktop/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Avalonia;
-using Avalonia.Platform;
 
 namespace Avalonia.PropertyGrid.Samples.Desktop;
 
@@ -19,13 +18,10 @@ internal sealed class Program
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace()
-            #if !DEBUG
-            .AfterSetup(builder=>
+            #if DEBUG
+            .AfterSetup(builder =>
             {
-                builder.Instance!.AttachDevTools(new Avalonia.Diagnostics.DevToolsOptions()
-                {
-                    StartupScreenIndex = 1,
-                });
+                builder.Instance!.AttachDeveloperTools();
             })
             #endif
             ;

--- a/Samples/Avalonia.PropertyGrid.Samples.iOS/Avalonia.PropertyGrid.Samples.iOS.csproj
+++ b/Samples/Avalonia.PropertyGrid.Samples.iOS/Avalonia.PropertyGrid.Samples.iOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-ios</TargetFramework>
+    <TargetFramework>net10.0-ios</TargetFramework>
     <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Development</Configurations>

--- a/Samples/Avalonia.PropertyGrid.Samples/App.axaml.cs
+++ b/Samples/Avalonia.PropertyGrid.Samples/App.axaml.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Linq;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
 using Avalonia.Platform;
 using Avalonia.PropertyGrid.Samples.Views;
@@ -40,10 +38,11 @@ public class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            // Avoid duplicate validations from both Avalonia and the CommunityToolkit. 
-            // More info: https://docs.avaloniaui.net/docs/guides/development-guides/data-validation#manage-validationplugins
-            DisableAvaloniaDataAnnotationValidation();
             desktop.MainWindow = new MainWindow();
+        }
+        else if (ApplicationLifetime is IActivityApplicationLifetime activityLifetime)
+        {
+            activityLifetime.MainViewFactory = () => new MainView();
         }
         else if (ApplicationLifetime is ISingleViewApplicationLifetime singleViewPlatform)
         {
@@ -59,19 +58,6 @@ public class App : Application
         }
 
         base.OnFrameworkInitializationCompleted();
-    }
-
-    private static void DisableAvaloniaDataAnnotationValidation()
-    {
-        // Get an array of plugins to remove
-        var dataValidationPluginsToRemove =
-            BindingPlugins.DataValidators.OfType<DataAnnotationsValidationPlugin>().ToArray();
-
-        // remove each entry found
-        foreach (var plugin in dataValidationPluginsToRemove)
-        {
-            BindingPlugins.DataValidators.Remove(plugin);
-        }
     }
 
     private ThemeType _prevTheme;
@@ -112,6 +98,10 @@ public class App : Application
                 desktopLifetime.MainWindow = newWindow;
                 newWindow.Show();
                 oldWindow?.Close();
+            }
+            else if (app.ApplicationLifetime is IActivityApplicationLifetime activityLifetime)
+            {
+                activityLifetime.MainViewFactory = () => new MainView();
             }
             else if (app.ApplicationLifetime is ISingleViewApplicationLifetime singleViewLifetime)
             {

--- a/Samples/Avalonia.PropertyGrid.Samples/Avalonia.PropertyGrid.Samples.csproj
+++ b/Samples/Avalonia.PropertyGrid.Samples/Avalonia.PropertyGrid.Samples.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <Configurations>Debug;Release;Development</Configurations>
@@ -19,7 +19,7 @@
         <PackageReference Include="Avalonia" />
         <PackageReference Include="Avalonia.Controls.ColorPicker" />
         <PackageReference Include="Avalonia.Controls.DataGrid" />
-        <PackageReference Include="Avalonia.Diagnostics" />
+        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Condition="'$(Configuration)' != 'Release'" />
         <PackageReference Include="Avalonia.Themes.Fluent" />
         <PackageReference Include="Avalonia.Fonts.Inter" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->

--- a/Samples/Avalonia.PropertyGrid.Samples/FeatureDemos/Views/CountryView.axaml
+++ b/Samples/Avalonia.PropertyGrid.Samples/FeatureDemos/Views/CountryView.axaml
@@ -1,6 +1,7 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="using:Avalonia.PropertyGrid.Samples.FeatureDemos.Views">
+        xmlns:controls="using:Avalonia.PropertyGrid.Samples.FeatureDemos.Views"
+        xmlns:models="using:Avalonia.PropertyGrid.Samples.FeatureDemos.Models">
   <Design.PreviewWith>
     <controls:CountryView />
   </Design.PreviewWith>
@@ -9,7 +10,7 @@
     <!-- Set Defaults -->
     <Setter Property="Template">
       <ControlTemplate>
-          <Grid RowDefinitions="Auto, Auto" ColumnDefinitions="Auto,Auto">
+          <Grid x:DataType="models:CountryInfo" RowDefinitions="Auto, Auto" ColumnDefinitions="Auto,Auto">
             <!-- ReSharper disable once Xaml.BindingWithoutContextNotResolved -->
             <Image Grid.RowSpan="2" Source="{Binding Flag}" Width="100" Height="60" Margin="2"></Image>
             <!-- ReSharper disable once Xaml.BindingWithoutContextNotResolved -->

--- a/Samples/Avalonia.PropertyGrid.Samples/FeatureDemos/Views/Vector3View.axaml
+++ b/Samples/Avalonia.PropertyGrid.Samples/FeatureDemos/Views/Vector3View.axaml
@@ -9,7 +9,7 @@
     <!-- Set Defaults -->
     <Setter Property="Template">
       <ControlTemplate>
-          <StackPanel Orientation="Horizontal">
+          <StackPanel x:DataType="controls:SVector3ViewModel" Orientation="Horizontal">
               <TextBlock Text="X" VerticalAlignment="Center" Padding="4"></TextBlock>
               <!-- ReSharper disable once Xaml.BindingWithoutContextNotResolved -->
               <NumericUpDown Value="{Binding X}"  ShowButtonSpinner="False">

--- a/Samples/Avalonia.PropertyGrid.Samples/PainterDemo/Views/GradientStopView.axaml
+++ b/Samples/Avalonia.PropertyGrid.Samples/PainterDemo/Views/GradientStopView.axaml
@@ -11,7 +11,7 @@
         <!-- Set Defaults -->
         <Setter Property="Template">
             <ControlTemplate>
-                <Grid ColumnDefinitions="Auto,Auto,*">
+                <Grid x:DataType="GradientStop" ColumnDefinitions="Auto,Auto,*">
                     <!-- ReSharper disable once Xaml.BindingWithoutContextNotResolved -->
                     <apc:PreviewableColorPicker Grid.Column="0" Name="Part_ColorPicker" Color="{Binding Color}"></apc:PreviewableColorPicker>
                     <!-- ReSharper disable once Xaml.BindingWithoutContextNotResolved -->

--- a/Samples/Avalonia.PropertyGrid.Samples/PainterDemo/Views/PainterView.axaml
+++ b/Samples/Avalonia.PropertyGrid.Samples/PainterDemo/Views/PainterView.axaml
@@ -7,7 +7,8 @@
              xmlns:ll="clr-namespace:Avalonia.PropertyGrid.Localization;assembly=Avalonia.PropertyGrid"
              xmlns:apvm="clr-namespace:Avalonia.PropertyGrid.ViewModels;assembly=Avalonia.PropertyGrid"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-             x:Class="Avalonia.PropertyGrid.Samples.PainterDemo.Views.PainterView">
+             x:Class="Avalonia.PropertyGrid.Samples.PainterDemo.Views.PainterView"
+             x:DataType="lvm:PainterViewModel">
     <UserControl.Resources>
         <apvm:EnumToBooleanConverter x:Key="EnumToBooleanConverter"/>
     </UserControl.Resources>

--- a/Samples/Avalonia.PropertyGrid.Samples/SettingsDemo/Views/SettingsView.axaml
+++ b/Samples/Avalonia.PropertyGrid.Samples/SettingsDemo/Views/SettingsView.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Avalonia.PropertyGrid.Samples.SettingsDemo.Views.SettingsView"
+             x:DataType="vm:SettingsViewModel"
              xmlns:vm="clr-namespace:Avalonia.PropertyGrid.Samples.SettingsDemo.ViewModels"
              xmlns:pgc="clr-namespace:Avalonia.PropertyGrid.Controls;assembly=Avalonia.PropertyGrid"
              >
@@ -14,7 +15,7 @@
     <Grid>
         <TabControl ItemsSource="{Binding FlatCategories}" SelectedIndex="0">
             <TabControl.ItemTemplate>
-                <DataTemplate>
+                <DataTemplate x:DataType="vm:FlatSettingCategory">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <TextBlock Text="{Binding Title}" FontSize="14"/>
                     </StackPanel>
@@ -22,7 +23,7 @@
             </TabControl.ItemTemplate>
             
             <TabControl.ContentTemplate>
-                <DataTemplate>
+                <DataTemplate x:DataType="vm:FlatSettingCategory">
                     <!-- ReSharper disable once Xaml.BindingWithContextNotResolved -->
                     <pgc:PropertyGrid IsTitleVisible="False"
                                       NameWidth="200"

--- a/Samples/Directory.Packages.props
+++ b/Samples/Directory.Packages.props
@@ -6,18 +6,18 @@
   <ItemGroup>
     <!-- Avalonia packages -->
     <!-- Important: keep version in sync! -->
-    <PackageVersion Include="Avalonia" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.11" />
-    <PackageVersion Include="Avalonia.iOS" Version="11.3.3" />
-    <PackageVersion Include="Avalonia.Browser" Version="11.3.3" />
-    <PackageVersion Include="Avalonia.Android" Version="11.3.3" />
-    <PackageVersion Include="Avalonia.Themes.Simple" Version="11.3.11" />
-    <PackageVersion Include="bodong.Avalonia.PropertyGrid" Version="11.3.11.1" />
+    <PackageVersion Include="Avalonia" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.0" />
+    <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.iOS" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Browser" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Android" Version="12.0.0" />
+    <PackageVersion Include="Avalonia.Themes.Simple" Version="12.0.0" />
+    <PackageVersion Include="bodong.Avalonia.PropertyGrid" Version="12.0.0" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="Quick.AvaloniaFonts.SourceHanSansCN" Version="1.0.0" />
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.16" />

--- a/Sources/Avalonia.PropertyGrid/Avalonia.PropertyGrid.csproj
+++ b/Sources/Avalonia.PropertyGrid/Avalonia.PropertyGrid.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFrameworks>netstandard2.1;net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 	  <LangVersion>preview</LangVersion>
 	  <GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">True</GeneratePackageOnBuild>
 	  <Title>bodong.Avalonia.PropertyGrid</Title>
-	  <Version>11.3.11.1</Version>
+		<Version>12.0.0</Version>
 	  <Authors>bodong</Authors>
-      <Nullable>enable</Nullable>
+    <Nullable>enable</Nullable>
 	  <Description>A PropertyGrid control implementation for Avalonia</Description>
 	  <PackageProjectUrl>https://github.com/bodong1987/Avalonia.PropertyGrid</PackageProjectUrl>
 	  <RepositoryUrl>https://github.com/bodong1987/Avalonia.PropertyGrid.git</RepositoryUrl>
@@ -46,12 +46,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.11" />
-    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.3.11" />
+    <PackageReference Include="Avalonia" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.0.0" />
   </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)' != 'Development'">
-        <PackageReference Include="bodong.PropertyModels" Version="11.3.11.1" />
+        <PackageReference Include="bodong.PropertyModels" Version="12.0.0" />
     </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Development'">
     <ProjectReference Include="..\PropertyModels\PropertyModels.csproj" />

--- a/Sources/Avalonia.PropertyGrid/Controls/ButtonEdit.axaml
+++ b/Sources/Avalonia.PropertyGrid/Controls/ButtonEdit.axaml
@@ -21,7 +21,7 @@
 								 VerticalContentAlignment="Center"
 								 FontFamily="{x:Static lu:FontUtils.DefaultFontFamily}"
 								 Text="{TemplateBinding Text, Mode=TwoWay}"
-                                 Watermark="{TemplateBinding Watermark, Mode=TwoWay}"
+								 PlaceholderText="{TemplateBinding Watermark, Mode=TwoWay}"
                                  IsReadOnly="{TemplateBinding IsReadOnly}"
 						   ></TextBox>
 						<Button x:Name="BrowserButton"

--- a/Sources/Avalonia.PropertyGrid/Controls/CheckedListEdit.axaml
+++ b/Sources/Avalonia.PropertyGrid/Controls/CheckedListEdit.axaml
@@ -17,7 +17,7 @@
                                 </ItemsPanelTemplate>
                             </ItemsControl.ItemsPanel>
                             <ItemsControl.ItemTemplate>
-                                <DataTemplate>
+                                <DataTemplate x:DataType="controls:CheckedListItemViewModel">
                                     <StackPanel Orientation="Horizontal">
                                         <CheckBox Margin="4, 2, 4, 2" IsChecked="{Binding IsChecked, Mode=TwoWay}">
                                             <TextBlock Margin="2,0,2,0" Text="{Binding Name}" VerticalAlignment="Center"></TextBlock>    

--- a/Sources/Avalonia.PropertyGrid/Controls/CheckedListEdit.axaml.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/CheckedListEdit.axaml.cs
@@ -141,7 +141,7 @@ public class CheckedListEdit : TemplatedControl
 /// Implements the <see cref="MiniReactiveObject" />
 /// </summary>
 /// <seealso cref="MiniReactiveObject" />
-internal class CheckedListViewModel : MiniReactiveObject
+public class CheckedListViewModel : MiniReactiveObject
 {
     /// <summary>
     /// The items
@@ -322,7 +322,7 @@ internal class CheckedListViewModel : MiniReactiveObject
 /// Implements the <see cref="MiniReactiveObject" />
 /// </summary>
 /// <seealso cref="MiniReactiveObject" />
-internal class CheckedListItemViewModel : MiniReactiveObject
+public class CheckedListItemViewModel : MiniReactiveObject
 {
     /// <summary>
     /// The parent

--- a/Sources/Avalonia.PropertyGrid/Controls/Factories/Builtins/PathCellEditFactory.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/Factories/Builtins/PathCellEditFactory.cs
@@ -2,7 +2,6 @@
 using Avalonia.Controls;
 using Avalonia.PropertyGrid.Localization;
 using Avalonia.PropertyGrid.Utils;
-using Avalonia.VisualTree;
 using PropertyModels.ComponentModel;
 using PropertyModels.ComponentModel.DataAnnotations;
 using PropertyModels.Extensions;
@@ -59,7 +58,7 @@ public class PathCellEditFactory : AbstractCellEditFactory
                 attribute.InitialFileName = control.Text;
             }
 
-            var files = await PathBrowserUtils.ShowPathBrowserAsync((control.GetVisualRoot() as Window)!, attribute);
+            var files = await PathBrowserUtils.ShowPathBrowserAsync((TopLevel.GetTopLevel(control) as Window)!, attribute);
 
             if (files is { Length: > 0 })
             {

--- a/Sources/Avalonia.PropertyGrid/Controls/Factories/Builtins/StringCellEditFactory.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/Factories/Builtins/StringCellEditFactory.cs
@@ -49,8 +49,8 @@ public class StringCellEditFactory : AbstractCellEditFactory
 
         if (watermarkAttr != null)
         {
-            // control.Watermark = LocalizationService.Default[watermarkAttr.Watermark];
-            control.SetLocalizeBinding(TextBox.WatermarkProperty, watermarkAttr.Watermark);
+            // control.PlaceholderText = LocalizationService.Default[watermarkAttr.Watermark];
+            control.SetLocalizeBinding(TextBox.PlaceholderTextProperty, watermarkAttr.Watermark);
         }
 
         var innerRightContentAttribute = propertyDescriptor.GetCustomAttribute<InnerRightContentStringAttribute>();

--- a/Sources/Avalonia.PropertyGrid/Controls/ListEdit.axaml
+++ b/Sources/Avalonia.PropertyGrid/Controls/ListEdit.axaml
@@ -82,7 +82,7 @@
 							  </ItemsPanelTemplate>
 						  </ItemsControl.ItemsPanel>
 						  <ItemsControl.ItemTemplate>
-							  <DataTemplate>
+							  <DataTemplate x:DataType="controls:ListElementDataDesc">
 								  <controls:ListElementEdit
 									  InsertCommand="{Binding InsertCommand}"
 									  RemoveCommand="{Binding RemoveCommand}"

--- a/Sources/Avalonia.PropertyGrid/Controls/ListEdit.axaml.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/ListEdit.axaml.cs
@@ -366,7 +366,7 @@ public class ListRoutedEventArgs : RoutedEventArgs
 /// Implements the <see cref="ReactiveObject" />
 /// </summary>
 /// <seealso cref="ReactiveObject" />
-internal class ListViewModel : ReactiveObject
+public class ListViewModel : ReactiveObject
 {
     /// <summary>
     /// Gets or sets the collection.
@@ -515,7 +515,7 @@ internal class ListViewModel : ReactiveObject
 /// Implements the <see cref="MiniReactiveObject" />
 /// </summary>
 /// <seealso cref="MiniReactiveObject" />
-internal class ListElementDataDesc : MiniReactiveObject
+public class ListElementDataDesc : MiniReactiveObject
 {
     /// <summary>
     /// The list

--- a/Sources/Avalonia.PropertyGrid/Controls/ListElementEdit.axaml
+++ b/Sources/Avalonia.PropertyGrid/Controls/ListElementEdit.axaml
@@ -16,9 +16,9 @@
 	</Styles.Resources>
 
   <Style Selector="controls|ListElementEdit">
-    <!-- Set Defaults -->
-    <Setter Property="Template">
-      <ControlTemplate>
+	<!-- Set Defaults -->
+	<Setter Property="Template">
+	  <ControlTemplate x:DataType="controls:ListElementDataDesc">
 		  <DataValidationErrors>
 			  <Grid ColumnDefinitions="36, *,Auto,Auto">
 				  <TextBlock Grid.Column="0" Text="{Binding DisplayName}" 

--- a/Sources/Avalonia.PropertyGrid/Controls/PreviewableColorPicker.axaml.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/PreviewableColorPicker.axaml.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 

--- a/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml
+++ b/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml
@@ -98,7 +98,7 @@
 		      RowDefinitions="*, Auto">
 			<!-- ReSharper disable once Xaml.StyleClassNotFound -->
 			<TextBox Grid.Row="0" Grid.Column="0" Classes="clearButton" x:Name="SearchTextBox"
-			         Watermark="{ll:Localize Search}" 
+					 PlaceholderText="{ll:Localize Search}"
 			         Text="{Binding $parent[lc:PropertyGrid].ViewModel.FilterPattern.FilterText}" ></TextBox>
 			<Button Grid.Row="0" Grid.Column="1" x:Name="OptionsButton"
 			        Click="OnOptionsButtonClicked"

--- a/Sources/Avalonia.PropertyGrid/Controls/RadioButtonListEdit.axaml
+++ b/Sources/Avalonia.PropertyGrid/Controls/RadioButtonListEdit.axaml
@@ -1,6 +1,7 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="using:Avalonia.PropertyGrid.Controls">
+		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+		xmlns:controls="using:Avalonia.PropertyGrid.Controls"
+		xmlns:vm="using:Avalonia.PropertyGrid.ViewModels">
   <Design.PreviewWith>
     <controls:RadioButtonListEdit />
   </Design.PreviewWith>
@@ -18,7 +19,7 @@
 						  </ItemsPanelTemplate>
 					  </ItemsControl.ItemsPanel>
 					  <ItemsControl.ItemTemplate>
-						  <DataTemplate>
+						  <DataTemplate x:DataType="vm:SingleSelectListItemViewModel">
 							  <RadioButton IsChecked="{Binding IsChecked, Mode=TwoWay}"
 							               MinWidth="{Binding MinWidth}"
 							               MinHeight="{Binding MinHeight}"

--- a/Sources/Avalonia.PropertyGrid/Controls/ToggleButtonGroupListEdit.axaml
+++ b/Sources/Avalonia.PropertyGrid/Controls/ToggleButtonGroupListEdit.axaml
@@ -1,6 +1,7 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="using:Avalonia.PropertyGrid.Controls">
+		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+		xmlns:controls="using:Avalonia.PropertyGrid.Controls"
+		xmlns:vm="using:Avalonia.PropertyGrid.ViewModels">
   <Design.PreviewWith>
     <controls:ToggleButtonGroupListEdit />
   </Design.PreviewWith>
@@ -18,8 +19,8 @@
 						  </ItemsPanelTemplate>
 					  </ItemsControl.ItemsPanel>
 					  <ItemsControl.ItemTemplate>
-						  <DataTemplate>
-							  <ToggleButton IsChecked="{Binding IsChecked, Mode=TwoWay}" Margin="4" 
+						  <DataTemplate x:DataType="vm:SingleSelectListItemViewModel">
+							  <ToggleButton IsChecked="{Binding IsChecked, Mode=TwoWay}"
 							                MinWidth="{Binding MinWidth}"
 							                MinHeight="{Binding MinHeight}"
 							                VerticalContentAlignment="Center"

--- a/Sources/Avalonia.PropertyGrid/ViewModels/SingleSelectListViewModel.cs
+++ b/Sources/Avalonia.PropertyGrid/ViewModels/SingleSelectListViewModel.cs
@@ -10,7 +10,7 @@ namespace Avalonia.PropertyGrid.ViewModels;
 /// Implements the <see cref="MiniReactiveObject" />
 /// </summary>
 /// <seealso cref="MiniReactiveObject" />
-internal class SingleSelectListViewModel : MiniReactiveObject
+public class SingleSelectListViewModel : MiniReactiveObject
 {
     /// <summary>
     /// The items
@@ -210,7 +210,7 @@ internal class SingleSelectListViewModel : MiniReactiveObject
 /// Implements the <see cref="MiniReactiveObject" />
 /// </summary>
 /// <seealso cref="MiniReactiveObject" />
-internal class SingleSelectListItemViewModel : MiniReactiveObject
+public class SingleSelectListItemViewModel : MiniReactiveObject
 {
     /// <summary>
     /// The parent

--- a/Sources/PropertyModels/PropertyModels.csproj
+++ b/Sources/PropertyModels/PropertyModels.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFrameworks>netstandard2.1;net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
+			<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 	  <LangVersion>preview</LangVersion>
 	  <Authors>bodong</Authors>
-	  <Version>11.3.11.1</Version>
+		<Version>12.0.0</Version>
 	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
 	  <GenerateDocumentationFile>True</GenerateDocumentationFile>
 	  <Nullable>enable</Nullable>
@@ -29,10 +29,6 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/UnitTests/Avalonia.PropertyGrid.UnitTests/Avalonia.PropertyGrid.UnitTests.csproj
+++ b/UnitTests/Avalonia.PropertyGrid.UnitTests/Avalonia.PropertyGrid.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     
     <IsPackable>false</IsPackable>

--- a/publish-web.bat
+++ b/publish-web.bat
@@ -22,7 +22,7 @@ if %errorlevel% neq 0 (
 )
 
 REM Navigate to the publish directory
-cd /d "%current_dir%\Samples\Avalonia.PropertyGrid.Samples.Browser\bin\Release\net9.0-browser\publish\wwwroot"
+cd /d "%current_dir%\Samples\Avalonia.PropertyGrid.Samples.Browser\bin\Release\net10.0-browser\publish\wwwroot"
 
 REM Recursively delete all .br and .gz files
 for /r %%i in (*.br *.gz) do del "%%i"


### PR DESCRIPTION
**Description**

Upgrade from Avalonia 11.x to 12.0.x

**Changes**
- Avalonia packages: Updated to 12.0.0
- Target frameworks: Dropped netstandard2.1 and net6.0; now net8.0 / net9.0 / net10.0 only
- Compiled bindings (enabled by default in V12): Added x:DataType annotations to DataTemplates and made several internal ViewModels public
- API renames: Watermark → PlaceholderText, GetVisualRoot() → TopLevel.GetTopLevel()
- Removed DisableAvaloniaDataAnnotationValidation() (no longer needed in V12)
- Android: New AvaloniaAndroidApplication<App> pattern + IActivityApplicationLifetime support
- DevTools: Use AvaloniaUI.DiagnosticsSupport with #if guard to attach only in DEBUG

**Breaking Changes**
- Minimum target is now net8.0 (same as Avalonia V12)
- Some previously internal ViewModels are now public (to enable compiled binding support)

**Notes**
I tried to keep changes to a minimum. Tested on desktop only so far. But this should give a good start for Avalonia V12.

Thanks btw for this great library :)