### PR TITLE
Fix memory leaks caused by unsubscription of event handlers

### DIFF
--- a/Sources/Avalonia.PropertyGrid/Avalonia.PropertyGrid.csproj
+++ b/Sources/Avalonia.PropertyGrid/Avalonia.PropertyGrid.csproj
@@ -50,10 +50,7 @@
     <PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.0.0" />
   </ItemGroup>
 
-    <ItemGroup Condition="'$(Configuration)' != 'Development'">
-        <PackageReference Include="bodong.PropertyModels" Version="12.0.0" />
-    </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' == 'Development'">
+  <ItemGroup>
     <ProjectReference Include="..\PropertyModels\PropertyModels.csproj" />
   </ItemGroup>
 

--- a/Sources/Avalonia.PropertyGrid/Localization/AssemblyJsonAssetLocalizationService.cs
+++ b/Sources/Avalonia.PropertyGrid/Localization/AssemblyJsonAssetLocalizationService.cs
@@ -200,4 +200,18 @@ public class AssemblyJsonAssetLocalizationService : MiniReactiveObject, ILocaliz
     /// <returns>ILocalizationService[].</returns>
     public ILocalizationService[] GetExtraServices() => [.. _extraServices];
     #endregion
+
+    // 只需要重写 Dispose 即可，不用再实现 IDisposable
+    protected override void Dispose( bool disposing )
+    {
+        if ( disposing )
+        {
+            _assetCultureData.SelectionChanged -= OnSelectionChanged;
+            OnCultureChanged = null;
+            CultureData?.Unload ( );
+            _extraServices.Clear ( );
+        }
+
+        base.Dispose ( disposing );
+    }
 }

--- a/Sources/Avalonia.PropertyGrid/Localization/LocalizationExtensions.cs
+++ b/Sources/Avalonia.PropertyGrid/Localization/LocalizationExtensions.cs
@@ -30,6 +30,13 @@ public static class LocalizationExtensions
 
         _ = control.Bind(property, binding);
         control.DataContext = source;
+
+        // 🔥 自动释放：控件销毁时自动 Dispose
+        control.Unloaded += ( s, e ) =>
+        {
+            ( source as IDisposable )?.Dispose ( );
+            control.DataContext = null;
+        };
     }
 }
 
@@ -59,4 +66,18 @@ internal class LocalizedDataModel : ReactiveObject
     }
 
     private void OnCultureChanged(object? sender, EventArgs e) => RaisePropertyChanged(nameof(Value));
+
+    protected override void Dispose( bool disposing )
+    {
+        if ( disposing )
+        {
+            try
+            {
+                LocalizationService.Default.OnCultureChanged -= OnCultureChanged;
+            }
+            catch { }
+        }
+
+        base.Dispose ( disposing );
+    }
 }

--- a/Sources/PropertyModels/ComponentModel/IReactiveObject.cs
+++ b/Sources/PropertyModels/ComponentModel/IReactiveObject.cs
@@ -18,7 +18,7 @@ public interface IReactiveObject : INotifyPropertyChanged;
 /// Implements the <see cref="PropertyModels.ComponentModel.IReactiveObject" />
 /// </summary>
 /// <seealso cref="PropertyModels.ComponentModel.IReactiveObject" />
-public class MiniReactiveObject : IReactiveObject
+public class MiniReactiveObject : IReactiveObject, IDisposable
 {
     #region Interfaces
     /// <summary>
@@ -80,6 +80,34 @@ public class MiniReactiveObject : IReactiveObject
         return false;
     }
     #endregion
+
+    private bool _disposed = false;
+    // ============================
+    // 标准 IDisposable（基类实现）
+    // ============================
+    public void Dispose( )
+    {
+        Dispose ( true );
+        GC.SuppressFinalize ( this );
+    }
+
+    protected virtual void Dispose( bool disposing )
+    {
+        if ( _disposed )
+            return;
+        _disposed = true;
+
+        if ( disposing )
+        {
+            // 清空事件，防止泄漏
+            PropertyChanged = null;
+        }
+    }
+
+    ~MiniReactiveObject( )
+    {
+        Dispose ( false );
+    }
 }
 
 
@@ -193,6 +221,19 @@ public class ReactiveObject : MiniReactiveObject
     }
 
     #endregion
+
+    // ============================
+    // 子类释放：取消自己的事件
+    // ============================
+    protected override void Dispose( bool disposing )
+    {
+        if ( disposing )
+        {
+            PropertyChanged -= ProcessPropertyChanged;
+        }
+
+        base.Dispose ( disposing );
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
Fixed several memory leaks:
1. Implement IDisposable on MiniReactiveObject base class
2. Unsubscribe PropertyChanged event in ReactiveObject
3. Unsubscribe static OnCultureChanged event in LocalizedDataModel
4. Auto dispose model when control is Unloaded
