### PR TITLE
Fix IsAutoNameWidth being ignored by nested property grids

### DIFF
--- a/Sources/Avalonia.PropertyGrid/Controls/Factories/Builtins/ExpandableCellEditFactory.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/Factories/Builtins/ExpandableCellEditFactory.cs
@@ -97,7 +97,7 @@ public class ExpandableCellEditFactory : AbstractCellEditFactory
         propertyGrid.IsHeaderVisible = false;
         propertyGrid.IsQuickFilterVisible = false;
         propertyGrid.IsTitleVisible = false;
-        propertyGrid.IsAutoNameWidth = false;
+        propertyGrid.IsAutoNameWidth = context.Root.IsAutoNameWidth;
         propertyGrid.DataContext = null;
 
         border.Child = propertyGrid;

--- a/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
+++ b/Sources/Avalonia.PropertyGrid/Controls/PropertyGrid.axaml.cs
@@ -687,8 +687,16 @@ public partial class PropertyGrid : UserControl, IPropertyGrid
         // change column width first
         var newWidth = NameWidth;
         SplitterGrid.ColumnDefinitions[0].Width = new GridLength(newWidth);
-            
-        // let's sync this width to all name text 
+
+        // in auto mode the name cells size themselves to their content, so no fixed width may be
+        // forced on them - not the one from the splitter, nor the one a nested grid picks up from
+        // its root grid
+        if (IsAutoNameWidth)
+        {
+            return;
+        }
+
+        // let's sync this width to all name text
         SyncNameWidth(newWidth, false);
     }
 


### PR DESCRIPTION
A `PropertyGrid` built for an expandable property was hard-coded to `IsAutoNameWidth = false`, so nested objects always rendered with the fixed name width. Such a grid is also created with `IsHeaderVisible = false` and so has no options menu of its own, leaving no way to turn the option on for it at all.

Inherit the value from the root grid instead, alongside `LayoutStyle`, `IsCategoryVisible` and the order styles already inherited there. Changing the option calls `BuildPropertiesView()`, which rebuilds the cell tree and recreates the nested grids, so a toggle reaches every nesting level.

Auto mode also has to survive a name-width change. A nested grid follows its root's `NameWidth`, and `OnNameWidthChanged` pushes that width onto every name cell, which undid the content-based sizing on the next splitter drag. Skip that sync when `IsAutoNameWidth` is set - the same condition`BuildPropertiesView` already uses before it forces the initial width. The splitter column is still updated, so the title row is unaffected.