### PR TITLE
Project structure simplified to make it more readable and clear.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,4 +3,23 @@
     <Nullable>enable</Nullable>
     <AvaloniaVersion>12.0.0</AvaloniaVersion>
   </PropertyGroup>
+
+  <!-- package related -->
+  <PropertyGroup>
+     <Authors>bodong</Authors>
+     <PackageProjectUrl>https://github.com/bodong1987/Avalonia.PropertyGrid</PackageProjectUrl>
+     <RepositoryUrl>https://github.com/bodong1987/Avalonia.PropertyGrid.git</RepositoryUrl>
+     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+     <IncludeSymbols>False</IncludeSymbols>
+     <Title>$(Authors).$(AssemblyName)</Title>
+  </PropertyGroup>
+
+  <PropertyGroup>		
+        <Title>$(Authors).Avalonia.PropertyGrid</Title>
+	<Product>$(Authors).Avalonia.PropertyGrid</Product>
+	<PackageReadmeFile>README_NUGET.md</PackageReadmeFile>
+	<GenerateDocumentationFile>True</GenerateDocumentationFile>
+        <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+
 </Project>

--- a/Sources/Avalonia.PropertyGrid/Avalonia.PropertyGrid.csproj
+++ b/Sources/Avalonia.PropertyGrid/Avalonia.PropertyGrid.csproj
@@ -1,25 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-	  <LangVersion>preview</LangVersion>
-	  <GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">True</GeneratePackageOnBuild>
-	  <Title>bodong.Avalonia.PropertyGrid</Title>
-		<Version>12.0.4.1</Version>
-	  <Authors>bodong</Authors>
-    <Nullable>enable</Nullable>
-	  <Description>A PropertyGrid control implementation for Avalonia</Description>
-	  <PackageProjectUrl>https://github.com/bodong1987/Avalonia.PropertyGrid</PackageProjectUrl>
-	  <RepositoryUrl>https://github.com/bodong1987/Avalonia.PropertyGrid.git</RepositoryUrl>
-	  <RepositoryType>git</RepositoryType>
-	  <PackageTags>Avalonia;PropertyGrid;AvaloniaControls;AvaloniaSamples</PackageTags>
+      <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+      <LangVersion>preview</LangVersion>
 	  <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
 	  <Configurations>Debug;Release;Development</Configurations>
   </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development|AnyCPU'">
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-    </PropertyGroup>
+  <!-- package related -->
+  <PropertyGroup>
+      <PackageId>$(Authors).Avalonia.PropertyGrid</PackageId>
+      <Version>12.0.4.1</Version>
+      <Description>A PropertyGrid control implementation for Avalonia</Description>
+      <PackageTags>Avalonia;PropertyGrid;AvaloniaControls;AvaloniaSamples</PackageTags>
+      <GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">True</GeneratePackageOnBuild>
+  </PropertyGroup>
+    
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development|AnyCPU'">
+      <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <None Remove="Assets\Localizations\en-US.json" />
@@ -31,11 +30,7 @@
     <AvaloniaResource Include="Assets\Localizations\en-US.json" />
     <AvaloniaResource Include="Assets\Localizations\ru-RU.json" />
     <AvaloniaResource Include="Assets\Localizations\zh-CN.json" />    
-    <AvaloniaResource Include="Assets\Images\options.png" />    
-    <AvaloniaResource Include="Assets\Images\add.png" />    
-    <AvaloniaResource Include="Assets\Images\delete.png" />
-      <AvaloniaResource Include="Assets\Images\new.png" />
-      <AvaloniaResource Include="Assets\Images\clear.png" />
+    <AvaloniaResource Include="Assets\Images\*.png" />
   </ItemGroup>
 
   <ItemGroup>
@@ -63,17 +58,5 @@
       <SubType>Code</SubType>
     </Compile>
   </ItemGroup>
-	
-	<PropertyGroup>		
-		<PackageId>bodong.Avalonia.PropertyGrid</PackageId>
-		<Product>bodong.Avalonia.PropertyGrid</Product>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<IncludeSymbols>False</IncludeSymbols>
-		<PackageReadmeFile>README_NUGET.md</PackageReadmeFile>
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<Nullable>enable</Nullable>
-	</PropertyGroup>
-
-	
 
 </Project>

--- a/Sources/PropertyModels/PropertyModels.csproj
+++ b/Sources/PropertyModels/PropertyModels.csproj
@@ -1,28 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-			<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-	  <LangVersion>preview</LangVersion>
-	  <Authors>bodong</Authors>
-		<Version>12.0.0</Version>
-	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
-	  <GenerateDocumentationFile>True</GenerateDocumentationFile>
-	  <Nullable>enable</Nullable>
-      <GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">True</GeneratePackageOnBuild>
-	  <PackageId>bodong.$(AssemblyName)</PackageId>
-	  <Title>bodong.$(AssemblyName)</Title>
-	  <Description>Some simple object model class libraries, originally used in the Avalonia.PropertyGrid project, were later split into an independent package in order to achieve the separation of data and presentation.</Description>
-	  <PackageProjectUrl>https://github.com/bodong1987/Avalonia.PropertyGrid</PackageProjectUrl>
-	  <RepositoryUrl>https://github.com/bodong1987/Avalonia.PropertyGrid.git</RepositoryUrl>
-	  <RepositoryType>git</RepositoryType>
-	  <PackageTags>Avalonia;PropertyGrid;AvaloniaControls;ObjectModel;ComponentModel</PackageTags>
-	  <PackageReadmeFile>README_PropertyModels.md</PackageReadmeFile>
-	  <Configurations>Debug;Release;Development</Configurations>
+      <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+      <LangVersion>preview</LangVersion>
+      <PackageReadmeFile>README_PropertyModels.md</PackageReadmeFile>
+      <Configurations>Debug;Release;Development</Configurations>
   </PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development|AnyCPU'">
-		<DefineConstants>DEBUG;TRACE</DefineConstants>
-	</PropertyGroup>
+  <!-- package related -->
+  <PropertyGroup>
+      <PackageId>$(Authors).$(AssemblyName)</PackageId>
+      <Version>12.0.0</Version>
+      <Description>Some simple object model class libraries, originally used in the Avalonia.PropertyGrid project, were later split into an independent package in order to achieve the separation of data and presentation.</Description>
+      <PackageTags>Avalonia;PropertyGrid;AvaloniaControls;ObjectModel;ComponentModel</PackageTags>
+      <GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">True</GeneratePackageOnBuild>
+  </PropertyGroup>
+    
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development|AnyCPU'">
+      <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
 	
   <ItemGroup>
     <None Include="..\README_PropertyModels.md">


### PR DESCRIPTION
Project structure was simplified to make it more readable and clear.
Common properties moved to directory.build.props.
Removed most properties duplication for /sources/*.csproj.
Properties group is more structurized now.